### PR TITLE
Selectable symmetry matrix IDs for define subparticles

### DIFF
--- a/localrec/protocols/protocol_localized.py
+++ b/localrec/protocols/protocol_localized.py
@@ -94,6 +94,13 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
                       condition='symGrp<=%d' % SYM_DIHEDRAL,
                       label='Symmetry Order',
                       help='Order of cyclic symmetry.')
+        group.addParam('symmetryMatrixIds', StringParam, default='',
+                       label='Symmetry matrix IDs',
+                       help='Optional comma-separated list of symmetry matrix '
+                            'IDs to use (for example: 1,3,5). IDs are '
+                            '1-based and must be between 1 and N, where N is '
+                            'the total number of matrices for the selected '
+                            'symmetry. If empty, all matrices are used.')
         group.addParam('randomize', BooleanParam, default=False,
                        label='Randomize the order of the symmetry matrices?',
                        help='Useful for preventing preferred orientations.')
@@ -174,6 +181,11 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
         elif sym == 11: sym = SYM_I2n5r
         symMatrices = getSymmetryMatrices(sym=sym,
                                           n=self.symmetryOrder.get())
+        selectedSymmetryMatrixIds = self._parseSymmetryMatrixIds(
+            self.symmetryMatrixIds.get(), len(symMatrices))
+        if selectedSymmetryMatrixIds:
+            symMatrices = [symMatrices[matrixId - 1]
+                           for matrixId in selectedSymmetryMatrixIds]
 ###ROB                                          n = self.symmetryOrder.get())
 #        for mat in symMatrices:
 #            print (mat)
@@ -230,7 +242,41 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
 
     # -------------------------- INFO functions --------------------------------
     def _validate(self):
-        pass
+        validateMsgs = []
+        sym = self.symGrp.get()
+        if sym == 0:
+            sym = SYM_CYCLIC
+        elif sym == 1:
+            sym = SYM_DIHEDRAL
+        elif sym == 2:
+            sym = SYM_TETRAHEDRAL
+        elif sym == 3:
+            sym = SYM_OCTAHEDRAL
+        elif sym == 4:
+            sym = SYM_I222
+        elif sym == 5:
+            sym = SYM_I222r
+        elif sym == 6:
+            sym = SYM_In25
+        elif sym == 7:
+            sym = SYM_In25r
+        elif sym == 8:
+            sym = SYM_I2n3
+        elif sym == 9:
+            sym = SYM_I2n3r
+        elif sym == 10:
+            sym = SYM_I2n5
+        elif sym == 11:
+            sym = SYM_I2n5r
+        symMatrices = getSymmetryMatrices(sym=sym, n=self.symmetryOrder.get())
+
+        try:
+            self._parseSymmetryMatrixIds(self.symmetryMatrixIds.get(),
+                                         len(symMatrices))
+        except ValueError as e:
+            validateMsgs.append(str(e))
+
+        return validateMsgs
 
     def _citations(self):
         return ['Ilca2015', 'Abrishami2020']
@@ -246,3 +292,32 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
     def _getOutpuVecMetadata(self):
         return self._getExtraPath('output_vectors.xmd')
 
+    @staticmethod
+    def _parseSymmetryMatrixIds(matrixIdsText, nSymmetryMatrices):
+        matrixIdsText = matrixIdsText.strip()
+        if not matrixIdsText:
+            return []
+
+        parsedIds = []
+        for token in matrixIdsText.split(','):
+            token = token.strip()
+            if not token:
+                raise ValueError('Symmetry matrix IDs contain empty values. '
+                                 'Please provide a comma-separated list of '
+                                 'integers.')
+            if not token.isdigit():
+                raise ValueError('Symmetry matrix IDs must be integers. '
+                                 'Invalid value: %s' % token)
+
+            matrixId = int(token)
+            if matrixId < 1 or matrixId > nSymmetryMatrices:
+                raise ValueError('Symmetry matrix IDs must be between 1 and '
+                                 '%d. Invalid value: %d'
+                                 % (nSymmetryMatrices, matrixId))
+            if matrixId in parsedIds:
+                raise ValueError('Symmetry matrix IDs contain duplicates. '
+                                 'Repeated value: %d' % matrixId)
+
+            parsedIds.append(matrixId)
+
+        return parsedIds


### PR DESCRIPTION
### Motivation
- Provide users of the `define subparticles` protocol a way to restrict which symmetry operators are used when generating subparticles by specifying a comma-separated list of symmetry matrix IDs in the GUI. 

### Description
- Added a new free-text parameter `symmetryMatrixIds` (type `StringParam`) to the `Symmetry` group in `localrec/protocols/protocol_localized.py` to accept a comma-separated list of 1-based matrix IDs. 
- Implemented a static helper ` _parseSymmetryMatrixIds(matrixIdsText, nSymmetryMatrices)` which parses, validates integer format, range (1..N), and duplicates, and returns a list of selected IDs (empty list means use all). 
- Wired parsing into execution and validation: `createOutputStep` filters the `symMatrices` returned by `getSymmetryMatrices` to only the selected operators when IDs are provided, and `_validate` calls the parser to surface format/range errors as validation messages.

### Testing
- Ran `python -m py_compile localrec/protocols/protocol_localized.py`, which succeeded. 
- Ran `pytest -q localrec/tests/test_protocol_localized_reconstruction.py`, which failed during collection in this environment due to a missing external dependency (`ModuleNotFoundError: No module named 'pwem'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac2084e50083268d69aff523fb2087)