### PR TITLE
Add symmetry group/operator metadata to localized subparticles

### DIFF
--- a/localrec/protocols/protocol_localized.py
+++ b/localrec/protocols/protocol_localized.py
@@ -165,6 +165,7 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
                   }
         # convert symmetry to scipion
         sym = self.symGrp.get()
+        symGrpParam = sym
         # symDict = {0: 'C', 1: 'D', 2: 'T', 3: 'O',
         # 4: 'I1', 5: 'I2', 6: 'I3', 7: 'I4'}
         if sym == 0: sym = SYM_CYCLIC
@@ -181,11 +182,23 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
         elif sym == 11: sym = SYM_I2n5r
         symMatrices = getSymmetryMatrices(sym=sym,
                                           n=self.symmetryOrder.get())
+        # group label = user-selected point group.
+        if symGrpParam == 0:
+            symmetryGroupLabel = 'C%d' % self.symmetryOrder.get()
+        elif symGrpParam == 1:
+            symmetryGroupLabel = 'D%d' % self.symmetryOrder.get()
+        else:
+            symmetryGroupLabel = ['T', 'O', 'I1', 'I2', 'I3',
+                                  'I4', 'I5', 'I6', 'I7', 'I8'][symGrpParam - 2]
+
+        # operator ID = 1-based index in the full symmetry operator set.
+        symmetryOperatorIds = list(range(1, len(symMatrices) + 1))
         selectedSymmetryMatrixIds = self._parseSymmetryMatrixIds(
             self.symmetryMatrixIds.get(), len(symMatrices))
         if selectedSymmetryMatrixIds:
             symMatrices = [symMatrices[matrixId - 1]
                            for matrixId in selectedSymmetryMatrixIds]
+            symmetryOperatorIds = selectedSymmetryMatrixIds
 ###ROB                                          n = self.symmetryOrder.get())
 #        for mat in symMatrices:
 #            print (mat)
@@ -228,7 +241,9 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
                                                self.randomize, 0,
                                                self.alignSubParticles,
                                                self.handness,
-                                               params["pxSize"])
+                                               params["pxSize"],
+                                               symmetryGroupLabel,
+                                               symmetryOperatorIds)
 
             for subpart in subparticles:
                 coord = subpart.getCoordinate()

--- a/localrec/utils.py
+++ b/localrec/utils.py
@@ -301,9 +301,17 @@ def filter_subparticles(subparticles, filters):
 
 def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
                         part_image_size, randomize, subparticles_total,
-                        align_subparticles, handness, angpix):
+                        align_subparticles, handness, angpix,
+                        symmetry_group_label=None,
+                        symmetry_operator_ids=None):
     """ Obtain all subparticles from a given particle and set
-    the properties of each such subparticle. """
+    the properties of each such subparticle.
+
+    :param symmetry_group_label: User-selected point group label (for example
+        C2, D7, O, I1) written to _symmetryGroup.
+    :param symmetry_operator_ids: Optional 1-based operator IDs aligned with
+        symmetry_matrices iteration, written to _symmetryOperatorId.
+    """
 
     # Euler angles that take particle to the orientation of the model
     matrix_particle = inv(particle.getTransform().getMatrix())
@@ -312,6 +320,10 @@ def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
     subparticles = []
     subparticles_total += 1
     symmetry_matrix_ids = range(1, len(symmetry_matrices) + 1)
+    if (symmetry_operator_ids is not None and
+            len(symmetry_operator_ids) != len(symmetry_matrices)):
+        raise ValueError("symmetry_operator_ids size must match "
+                         "symmetry_matrices size.")
 
     if randomize:
         # randomize the order of symmetry matrices, prevents preferred views
@@ -324,6 +336,9 @@ def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
             # symmetry_matrix_id can be later written out to find out
             # which symmetry matrix created this subparticle
             symmetry_matrix = np.array(symmetry_matrices[symmetry_matrix_id - 1][0:3, 0:3])
+            symmetry_operator_id = (symmetry_operator_ids[symmetry_matrix_id - 1]
+                                    if symmetry_operator_ids is not None
+                                    else symmetry_matrix_id)
 
             subpart = particle.clone()
             m = np.matmul(matrix_particle[0:3, 0:3], (np.matmul(symmetry_matrix.transpose(),
@@ -370,6 +385,10 @@ def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
                 ctf.setDefocusV(subpart.getCTF().getDefocusV() + z_ang)
 
             subpart.setCoordinate(coord)
+            # group label = user-selected point group.
+            subpart._symmetryGroup = str(symmetry_group_label or "")
+            # operator ID = 1-based index in the full symmetry operator set.
+            subpart._symmetryOperatorId = int(symmetry_operator_id)
             coord._subparticle = subpart.clone()
             subparticles.append(subpart)
 


### PR DESCRIPTION
### Motivation
- Persist the user-selected point-group label and per-operator identifier on each generated subparticle so downstream clone-based flows (e.g. `coord._subparticle = subpart.clone()`, extraction/filter cloning) retain that symmetry metadata.
- Allow passing an explicit mapping of operator IDs aligned with the symmetry matrices iteration so selected subsets of matrices preserve original 1-based operator IDs.

### Description
- Extended `create_subparticles(...)` signature in `localrec/utils.py` to accept `symmetry_group_label` and optional `symmetry_operator_ids` and added a docstring describing their semantics.
- Added a size check that raises `ValueError` if `symmetry_operator_ids` is provided with a length that does not match `symmetry_matrices`.
- Inside the symmetry loop, before cloning/appending, set `subpart._symmetryGroup` to the provided `symmetry_group_label` and `subpart._symmetryOperatorId` to the 1-based operator ID (either from the mapping or the current matrix index).
- Updated `ProtLocalizedRecons.createOutputStep` in `localrec/protocols/protocol_localized.py` to compute the user-facing group label (e.g. `C{n}`, `D{n}`, `T`, `O`, `I1`...) and to build/pass `symmetryOperatorIds` (a full-set 1-based list that is then adjusted when `symmetryMatrixIds` filters matrices).

### Testing
- Compiled the modified modules with `python -m compileall localrec/utils.py localrec/protocols/protocol_localized.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c436ebb3b483269ccb409cafa047b2)