### PR TITLE
Preserve original symmetry matrix IDs when creating subparticles

### DIFF
--- a/localrec/protocols/protocol_localized.py
+++ b/localrec/protocols/protocol_localized.py
@@ -165,6 +165,7 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
                   }
         # convert symmetry to scipion
         sym = self.symGrp.get()
+        symGrpParam = sym
         # symDict = {0: 'C', 1: 'D', 2: 'T', 3: 'O',
         # 4: 'I1', 5: 'I2', 6: 'I3', 7: 'I4'}
         if sym == 0: sym = SYM_CYCLIC
@@ -181,11 +182,23 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
         elif sym == 11: sym = SYM_I2n5r
         symMatrices = getSymmetryMatrices(sym=sym,
                                           n=self.symmetryOrder.get())
+        # group label = user-selected point group.
+        if symGrpParam == 0:
+            symmetryGroupLabel = 'C%d' % self.symmetryOrder.get()
+        elif symGrpParam == 1:
+            symmetryGroupLabel = 'D%d' % self.symmetryOrder.get()
+        else:
+            symmetryGroupLabel = ['T', 'O', 'I1', 'I2', 'I3',
+                                  'I4', 'I5', 'I6', 'I7', 'I8'][symGrpParam - 2]
+
+        # operator ID = 1-based index in the full symmetry operator set.
+        symmetryOperatorIds = list(range(1, len(symMatrices) + 1))
         selectedSymmetryMatrixIds = self._parseSymmetryMatrixIds(
             self.symmetryMatrixIds.get(), len(symMatrices))
         if selectedSymmetryMatrixIds:
             symMatrices = [symMatrices[matrixId - 1]
                            for matrixId in selectedSymmetryMatrixIds]
+            symmetryOperatorIds = selectedSymmetryMatrixIds
 ###ROB                                          n = self.symmetryOrder.get())
 #        for mat in symMatrices:
 #            print (mat)
@@ -228,7 +241,9 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
                                                self.randomize, 0,
                                                self.alignSubParticles,
                                                self.handness,
-                                               params["pxSize"])
+                                               params["pxSize"],
+                                               symmetryGroupLabel,
+                                               symmetryOperatorIds)
 
             for subpart in subparticles:
                 coord = subpart.getCoordinate()

--- a/localrec/protocols/protocol_localized.py
+++ b/localrec/protocols/protocol_localized.py
@@ -179,13 +179,19 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
         elif sym == 9: sym = SYM_I2n3r
         elif sym == 10: sym = SYM_I2n5
         elif sym == 11: sym = SYM_I2n5r
-        symMatrices = getSymmetryMatrices(sym=sym,
-                                          n=self.symmetryOrder.get())
+        allSymMatrices = getSymmetryMatrices(sym=sym,
+                                             n=self.symmetryOrder.get())
+        # NOTE: selectedSymmetryMatrixIds are always 1-based IDs that refer to
+        # the full symmetry set (allSymMatrices), never to a filtered position.
         selectedSymmetryMatrixIds = self._parseSymmetryMatrixIds(
-            self.symmetryMatrixIds.get(), len(symMatrices))
+            self.symmetryMatrixIds.get(), len(allSymMatrices))
         if selectedSymmetryMatrixIds:
-            symMatrices = [symMatrices[matrixId - 1]
-                           for matrixId in selectedSymmetryMatrixIds]
+            symMatricesWithIds = [(matrixId, allSymMatrices[matrixId - 1])
+                                  for matrixId in selectedSymmetryMatrixIds]
+        else:
+            # Keep backward-compatible IDs when no subset is provided: 1..N of
+            # the complete symmetry set.
+            symMatricesWithIds = list(enumerate(allSymMatrices, start=1))
 ###ROB                                          n = self.symmetryOrder.get())
 #        for mat in symMatrices:
 #            print (mat)
@@ -222,7 +228,7 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
             if i % step == 0:
                 progress.update(i+1)
 
-            subparticles = create_subparticles(part, symMatrices,
+            subparticles = create_subparticles(part, symMatricesWithIds,
                                                subpartVectorList,
                                                params["dim"],
                                                self.randomize, 0,

--- a/localrec/utils.py
+++ b/localrec/utils.py
@@ -301,9 +301,17 @@ def filter_subparticles(subparticles, filters):
 
 def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
                         part_image_size, randomize, subparticles_total,
-                        align_subparticles, handness, angpix):
+                        align_subparticles, handness, angpix,
+                        symmetry_group_label=None,
+                        symmetry_operator_ids=None):
     """ Obtain all subparticles from a given particle and set
-    the properties of each such subparticle. """
+    the properties of each such subparticle.
+
+    :param symmetry_group_label: User-selected point group label (for example
+        C2, D7, O, I1) written to _symmetryGroup.
+    :param symmetry_operator_ids: Optional 1-based operator IDs aligned with
+        symmetry_matrices iteration, written to _symmetryOperatorId.
+    """
 
     # Euler angles that take particle to the orientation of the model
     matrix_particle = inv(particle.getTransform().getMatrix())
@@ -312,6 +320,10 @@ def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
     subparticles = []
     subparticles_total += 1
     symmetry_matrix_ids = range(1, len(symmetry_matrices) + 1)
+    if (symmetry_operator_ids is not None and
+            len(symmetry_operator_ids) != len(symmetry_matrices)):
+        raise ValueError("symmetry_operator_ids size must match "
+                         "symmetry_matrices size.")
 
     if randomize:
         # randomize the order of symmetry matrices, prevents preferred views
@@ -324,6 +336,9 @@ def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
             # symmetry_matrix_id can be later written out to find out
             # which symmetry matrix created this subparticle
             symmetry_matrix = np.array(symmetry_matrices[symmetry_matrix_id - 1][0:3, 0:3])
+            symmetry_operator_id = (symmetry_operator_ids[symmetry_matrix_id - 1]
+                                    if symmetry_operator_ids is not None
+                                    else symmetry_matrix_id)
 
             subpart = particle.clone()
             m = np.matmul(matrix_particle[0:3, 0:3], (np.matmul(symmetry_matrix.transpose(),
@@ -370,6 +385,10 @@ def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
                 ctf.setDefocusV(subpart.getCTF().getDefocusV() + z_ang)
 
             subpart.setCoordinate(coord)
+            # group label = user-selected point group.
+            subpart._symmetryGroup = str(symmetry_group_label or "")
+            # operator ID = 1-based index in the full symmetry operator set.
+            subpart._symmetryOperatorId = int(symmetry_operator_id)
             coord._subparticle = subpart.clone()
             subparticles.append(subpart)
 

--- a/localrec/utils.py
+++ b/localrec/utils.py
@@ -299,7 +299,7 @@ def filter_subparticles(subparticles, filters):
             if all(f(subparticles, sp) for f in filters)]
 
 
-def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
+def create_subparticles(particle, symmetry_matrices_with_ids, subparticle_vector_list,
                         part_image_size, randomize, subparticles_total,
                         align_subparticles, handness, angpix):
     """ Obtain all subparticles from a given particle and set
@@ -311,19 +311,19 @@ def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
 
     subparticles = []
     subparticles_total += 1
-    symmetry_matrix_ids = range(1, len(symmetry_matrices) + 1)
-
+    matrix_items = list(symmetry_matrices_with_ids)
     if randomize:
         # randomize the order of symmetry matrices, prevents preferred views
-        random.shuffle(symmetry_matrix_ids)
+        random.shuffle(matrix_items)
 
     for subparticle_vector in subparticle_vector_list:
         matrix_from_subparticle_vector = subparticle_vector.get_matrix()
 
-        for symmetry_matrix_id in symmetry_matrix_ids:
+        for symmetry_matrix_id, symmetry_matrix in matrix_items:
             # symmetry_matrix_id can be later written out to find out
-            # which symmetry matrix created this subparticle
-            symmetry_matrix = np.array(symmetry_matrices[symmetry_matrix_id - 1][0:3, 0:3])
+            # which symmetry matrix created this subparticle. It must refer to
+            # the original full symmetry-set ID.
+            symmetry_matrix = np.array(symmetry_matrix[0:3, 0:3])
 
             subpart = particle.clone()
             m = np.matmul(matrix_particle[0:3, 0:3], (np.matmul(symmetry_matrix.transpose(),
@@ -370,6 +370,7 @@ def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
                 ctf.setDefocusV(subpart.getCTF().getDefocusV() + z_ang)
 
             subpart.setCoordinate(coord)
+            coord._symmetryOperatorId = symmetry_matrix_id
             coord._subparticle = subpart.clone()
             subparticles.append(subpart)
 


### PR DESCRIPTION
### Motivation
- Selected symmetry matrices were being indexed by their position in a filtered list, which caused stored symmetry operator IDs to reflect the subset order instead of the original full-set IDs.
- Ensure that any explicitly provided matrix IDs always refer to the full symmetry set so downstream code and metadata consistently reference original operator IDs.

### Description
- Keep the full symmetry set in `createOutputStep` as `allSymMatrices` and parse `symmetryMatrixIds` against that full list using `self._parseSymmetryMatrixIds`.
- Build explicit `(original_id, matrix)` pairs in `symMatricesWithIds`, and fall back to `list(enumerate(allSymMatrices, start=1))` when no subset is provided to preserve 1..N behavior.
- Change `create_subparticles(...)` to accept `symmetry_matrices_with_ids` and iterate `for symmetry_matrix_id, symmetry_matrix in ...` so the original full-set ID is preserved when constructing subparticles.
- Store the original operator ID on generated coordinates via `coord._symmetryOperatorId = symmetry_matrix_id` and add comments documenting the invariant that parsed IDs are full-set IDs.

### Testing
- Ran `python -m compileall localrec/protocols/protocol_localized.py localrec/utils.py`, which completed successfully (files compiled without syntax errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4391283d48326ba539b31c5039df4)