### PR TITLE
Add resilient subparticle provenance handling, persist operator IDs, and export/test support

### DIFF
--- a/localrec/protocols/protocol_filter_subparticles.py
+++ b/localrec/protocols/protocol_filter_subparticles.py
@@ -120,6 +120,7 @@ class ProtFilterSubParts(ProtParticles):
         lastPartId = None
         particlesList = []
         isSubPart = False;
+        missingProvenanceWarned = False
         firstParticle = inputSet.getFirstItem()
         if firstParticle.hasAttribute('_transorg'):
             isSubPart = True;
@@ -144,6 +145,13 @@ class ProtFilterSubParts(ProtParticles):
                 particlesList = []
 
             subpart = particle.clone()
+            if (isSubPart and not missingProvenanceWarned and
+                    not has_subparticle_provenance(subpart)):
+                self.warning("Subparticle provenance fields "
+                             "(_symmetryGroup/_symmetryOperatorId) are "
+                             "missing for some items. Continuing without "
+                             "failing.")
+                missingProvenanceWarned = True
             if (isSubPart):
                 _, cAngles = geometryFromMatrix(inv(particle._transorg.getMatrix()))
             else:
@@ -171,6 +179,7 @@ class ProtFilterSubParts(ProtParticles):
         subParticles = []
         coordArr = []
         subParticleId = 0
+        missingProvenanceWarned = False
 
         progress = ProgressBar(len(inputSet), fmt=ProgressBar.NOBAR)
         print("Processing coordinates:")
@@ -195,6 +204,13 @@ class ProtFilterSubParts(ProtParticles):
                 lastPartId = partId
 
             subParticle = coord._subparticle
+            if (not missingProvenanceWarned and
+                    not has_subparticle_provenance(subParticle)):
+                self.warning("Subparticle provenance fields "
+                             "(_symmetryGroup/_symmetryOperatorId) are "
+                             "missing for some items. Continuing without "
+                             "failing.")
+                missingProvenanceWarned = True
             subpart = subParticle.clone()
             _, cAngles = geometryFromMatrix(inv(subParticle._transorg.getMatrix()))
             subpart._angles = cAngles

--- a/localrec/protocols/protocol_localized.py
+++ b/localrec/protocols/protocol_localized.py
@@ -165,6 +165,7 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
                   }
         # convert symmetry to scipion
         sym = self.symGrp.get()
+        symGrpParam = sym
         # symDict = {0: 'C', 1: 'D', 2: 'T', 3: 'O',
         # 4: 'I1', 5: 'I2', 6: 'I3', 7: 'I4'}
         if sym == 0: sym = SYM_CYCLIC
@@ -181,11 +182,23 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
         elif sym == 11: sym = SYM_I2n5r
         symMatrices = getSymmetryMatrices(sym=sym,
                                           n=self.symmetryOrder.get())
+        # group label = user-selected point group.
+        if symGrpParam == 0:
+            symmetryGroupLabel = 'C%d' % self.symmetryOrder.get()
+        elif symGrpParam == 1:
+            symmetryGroupLabel = 'D%d' % self.symmetryOrder.get()
+        else:
+            symmetryGroupLabel = ['T', 'O', 'I1', 'I2', 'I3',
+                                  'I4', 'I5', 'I6', 'I7', 'I8'][symGrpParam - 2]
+
+        # operator ID = 1-based index in the full symmetry operator set.
+        symmetryOperatorIds = list(range(1, len(symMatrices) + 1))
         selectedSymmetryMatrixIds = self._parseSymmetryMatrixIds(
             self.symmetryMatrixIds.get(), len(symMatrices))
         if selectedSymmetryMatrixIds:
             symMatrices = [symMatrices[matrixId - 1]
                            for matrixId in selectedSymmetryMatrixIds]
+            symmetryOperatorIds = selectedSymmetryMatrixIds
 ###ROB                                          n = self.symmetryOrder.get())
 #        for mat in symMatrices:
 #            print (mat)
@@ -228,7 +241,9 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
                                                self.randomize, 0,
                                                self.alignSubParticles,
                                                self.handness,
-                                               params["pxSize"])
+                                               params["pxSize"],
+                                               symmetryGroupLabel,
+                                               symmetryOperatorIds)
 
             for subpart in subparticles:
                 coord = subpart.getCoordinate()

--- a/localrec/protocols/protocol_localized.py
+++ b/localrec/protocols/protocol_localized.py
@@ -179,13 +179,19 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
         elif sym == 9: sym = SYM_I2n3r
         elif sym == 10: sym = SYM_I2n5
         elif sym == 11: sym = SYM_I2n5r
-        symMatrices = getSymmetryMatrices(sym=sym,
-                                          n=self.symmetryOrder.get())
+        allSymMatrices = getSymmetryMatrices(sym=sym,
+                                             n=self.symmetryOrder.get())
+        # NOTE: selectedSymmetryMatrixIds are always 1-based IDs that refer to
+        # the full symmetry set (allSymMatrices), never to a filtered position.
         selectedSymmetryMatrixIds = self._parseSymmetryMatrixIds(
-            self.symmetryMatrixIds.get(), len(symMatrices))
+            self.symmetryMatrixIds.get(), len(allSymMatrices))
         if selectedSymmetryMatrixIds:
-            symMatrices = [symMatrices[matrixId - 1]
-                           for matrixId in selectedSymmetryMatrixIds]
+            symMatricesWithIds = [(matrixId, allSymMatrices[matrixId - 1])
+                                  for matrixId in selectedSymmetryMatrixIds]
+        else:
+            # Keep backward-compatible IDs when no subset is provided: 1..N of
+            # the complete symmetry set.
+            symMatricesWithIds = list(enumerate(allSymMatrices, start=1))
 ###ROB                                          n = self.symmetryOrder.get())
 #        for mat in symMatrices:
 #            print (mat)
@@ -222,7 +228,7 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
             if i % step == 0:
                 progress.update(i+1)
 
-            subparticles = create_subparticles(part, symMatrices,
+            subparticles = create_subparticles(part, symMatricesWithIds,
                                                subpartVectorList,
                                                params["dim"],
                                                self.randomize, 0,

--- a/localrec/protocols/protocol_localized.py
+++ b/localrec/protocols/protocol_localized.py
@@ -186,6 +186,9 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
         if selectedSymmetryMatrixIds:
             symMatrices = [symMatrices[matrixId - 1]
                            for matrixId in selectedSymmetryMatrixIds]
+            operatorIds = selectedSymmetryMatrixIds
+        else:
+            operatorIds = list(range(1, len(symMatrices) + 1))
 ###ROB                                          n = self.symmetryOrder.get())
 #        for mat in symMatrices:
 #            print (mat)
@@ -228,7 +231,9 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
                                                self.randomize, 0,
                                                self.alignSubParticles,
                                                self.handness,
-                                               params["pxSize"])
+                                               params["pxSize"],
+                                               symmetry_operator_ids=operatorIds,
+                                               symmetry_group=sym)
 
             for subpart in subparticles:
                 coord = subpart.getCoordinate()

--- a/localrec/protocols/protocol_localized_extraction.py
+++ b/localrec/protocols/protocol_localized_extraction.py
@@ -34,6 +34,7 @@ from pyworkflow.protocol.params import IntParam
 # eventually progressbar will be move to scipion core
 from pyworkflow.utils import ProgressBar
 from pwem.objects import SetOfParticles
+from localrec.utils import has_subparticle_provenance
 
 
 class ProtLocalizedExtraction(ProtParticles):
@@ -92,6 +93,7 @@ class ProtLocalizedExtraction(ProtParticles):
         outliers = 0
         partIdExcluded = []
         lastPartId = None
+        missingProvenanceWarned = False
 
         progress = ProgressBar(len(inputCoords), fmt=ProgressBar.NOBAR)
         progress.start()
@@ -139,6 +141,13 @@ class ProtLocalizedExtraction(ProtParticles):
                 i += 1
                 outputImg.write((i, outputStack))
                 subpart = coord._subparticle
+                if (not missingProvenanceWarned and
+                        not has_subparticle_provenance(subpart)):
+                    self.warning("Subparticle provenance fields "
+                                 "(_symmetryGroup/_symmetryOperatorId) are "
+                                 "missing for some items. Continuing without "
+                                 "failing.")
+                    missingProvenanceWarned = True
                 subpart.setLocation(
                     (i, outputStack))  # Change path to new stack
                 subpart.setObjId(i)  # Ids will be always the same no mater the number of outliers 

--- a/localrec/protocols/protocol_subparticle_statistics.py
+++ b/localrec/protocols/protocol_subparticle_statistics.py
@@ -16,6 +16,7 @@ import os
 from pyworkflow import VERSION_3_0
 from pyworkflow.protocol.params import PointerParam, IntParam, StringParam
 from pwem.protocols import ProtParticles
+from localrec.utils import get_subparticle_provenance
 
 
 class ProtSubparticleStatistics(ProtParticles):
@@ -78,10 +79,15 @@ class ProtSubparticleStatistics(ProtParticles):
                                          allow_empty=True)
 
         per_particle_counts = {}
+        provenance_summary = {'withProvenance': 0, 'missingProvenance': 0}
 
-        for parent_id, class_id in self._iterAssignments(classification):
+        for parent_id, class_id, has_provenance in self._iterAssignments(classification):
             if parent_id not in per_particle_counts:
                 per_particle_counts[parent_id] = [0, 0]
+            if has_provenance:
+                provenance_summary['withProvenance'] += 1
+            else:
+                provenance_summary['missingProvenance'] += 1
 
             if class_id in group1_ids:
                 per_particle_counts[parent_id][0] += 1
@@ -92,13 +98,20 @@ class ProtSubparticleStatistics(ProtParticles):
         if not per_particle_counts:
             raise Exception('No subparticle assignments found in the selected '
                             'classification input.')
+        if provenance_summary['missingProvenance'] > 0:
+            self.warning('Subparticle provenance fields '
+                         '(_symmetryGroup/_symmetryOperatorId) were missing in '
+                         '%d items. Continuing statistics computation.'
+                         % provenance_summary['missingProvenance'])
 
         if group2_ids:
-            self._write2DHistogram(per_particle_counts, group1_ids, group2_ids)
+            self._write2DHistogram(per_particle_counts, group1_ids, group2_ids,
+                                   provenance_summary)
         else:
-            self._write1DHistogram(per_particle_counts, group1_ids)
+            self._write1DHistogram(per_particle_counts, group1_ids,
+                                   provenance_summary)
 
-    def _write1DHistogram(self, per_particle_counts, group1_ids):
+    def _write1DHistogram(self, per_particle_counts, group1_ids, provenance_summary):
         counts_group1 = [count_pair[0] for count_pair in per_particle_counts.values()]
 
         auto_n = max(counts_group1)
@@ -124,6 +137,7 @@ class ProtSubparticleStatistics(ProtParticles):
             'maxCount': n,
             'overflow': overflow,
             'totalParticles': len(per_particle_counts),
+            'provenance': provenance_summary,
             'bins': bins,
             'counts': [histogram[k] for k in bins]
         }
@@ -134,11 +148,15 @@ class ProtSubparticleStatistics(ProtParticles):
 
         with open(csv_path, 'w') as handle:
             writer = csv.writer(handle)
-            writer.writerow(['category_k', 'particle_count'])
+            writer.writerow(['category_k', 'particle_count',
+                             'with_provenance', 'missing_provenance'])
             for k in bins:
-                writer.writerow([k, histogram[k]])
+                writer.writerow([k, histogram[k],
+                                 provenance_summary['withProvenance'],
+                                 provenance_summary['missingProvenance']])
 
-    def _write2DHistogram(self, per_particle_counts, group1_ids, group2_ids):
+    def _write2DHistogram(self, per_particle_counts, group1_ids, group2_ids,
+                          provenance_summary):
         pairs = [tuple(count_pair) for count_pair in per_particle_counts.values()]
         x_auto = max(pair[0] for pair in pairs)
         y_auto = max(pair[1] for pair in pairs)
@@ -170,6 +188,7 @@ class ProtSubparticleStatistics(ProtParticles):
             'maxCount': n,
             'overflow': overflow,
             'totalParticles': len(per_particle_counts),
+            'provenance': provenance_summary,
             'points': points
         }
 
@@ -179,9 +198,13 @@ class ProtSubparticleStatistics(ProtParticles):
 
         with open(csv_path, 'w') as handle:
             writer = csv.writer(handle)
-            writer.writerow(['x_count_group1', 'y_count_group2', 'particle_frequency'])
+            writer.writerow(['x_count_group1', 'y_count_group2',
+                             'particle_frequency', 'with_provenance',
+                             'missing_provenance'])
             for point in points:
-                writer.writerow([point['x'], point['y'], point['frequency']])
+                writer.writerow([point['x'], point['y'], point['frequency'],
+                                 provenance_summary['withProvenance'],
+                                 provenance_summary['missingProvenance']])
 
     def _resolveMaxCount(self, auto_n):
         user_n = int(self.maxCount.get())
@@ -205,7 +228,9 @@ class ProtSubparticleStatistics(ProtParticles):
                 cls_items = cls
             for item in cls_items:
                 parent_id = self._getParentParticleId(item)
-                yield parent_id, class_id
+                sym_group, operator_id = get_subparticle_provenance(item)
+                has_provenance = sym_group is not None and operator_id is not None
+                yield parent_id, class_id, has_provenance
 
     @staticmethod
     def _getClassId(cls):

--- a/localrec/tests/test_protocol_localized_reconstruction.py
+++ b/localrec/tests/test_protocol_localized_reconstruction.py
@@ -255,6 +255,62 @@ class TestLocalizedRecons(TestLocalizedReconsBase):
         self.assertTrue(coordinate.getObjId() == 1)
         self.assertTrue(coordinate.getMicId() == 1)
 
+    def _extract_provenance(self, coord):
+        return get_subparticle_provenance(coord._subparticle)
+
+    def testSubparticleProvenanceFields(self):
+        prot = self._runSubparticles(600, [-1.2, 111.6, -177.4],
+                                     alignSubParticles=False)
+        first_coord = prot.outputCoordinates.getFirstItem()
+        sym_group, operator_id = self._extract_provenance(first_coord)
+
+        self.assertIsNotNone(sym_group)
+        self.assertIsNotNone(operator_id)
+        self.assertEqual(SYM_I222, int(sym_group))
+
+    def testSubparticleProvenanceSubsetOperatorIds(self):
+        prot = self.newProtocol(ProtLocalizedRecons,
+                                objLabel='subset symmetry ids',
+                                symGrp=SYM_I222,
+                                symmetryMatrixIds='1,3,5',
+                                defineVector=0,
+                                alignSubParticles=False)
+        prot.inputParticles.set(self.protImport.outputParticles)
+        prot.vectorFile.set(self.chimeraFile)
+        self.launchProtocol(prot)
+
+        operator_ids = set()
+        sample_sequence = []
+        for i, coord in enumerate(prot.outputCoordinates.iterItems()):
+            _, operator_id = self._extract_provenance(coord)
+            operator_ids.add(int(operator_id))
+            if i < 30:
+                sample_sequence.append(int(operator_id))
+            if len(operator_ids) == 3 and i > 200:
+                break
+
+        self.assertSetEqual({1, 3, 5}, operator_ids)
+
+        prot_second = self.newProtocol(ProtLocalizedRecons,
+                                       objLabel='subset symmetry ids second run',
+                                       symGrp=SYM_I222,
+                                       symmetryMatrixIds='1,3,5',
+                                       defineVector=0,
+                                       alignSubParticles=False)
+        prot_second.inputParticles.set(self.protImport.outputParticles)
+        prot_second.vectorFile.set(self.chimeraFile)
+        self.launchProtocol(prot_second)
+
+        sample_sequence_second = []
+        for i, coord in enumerate(prot_second.outputCoordinates.iterItems()):
+            _, operator_id = self._extract_provenance(coord)
+            if i < 30:
+                sample_sequence_second.append(int(operator_id))
+            else:
+                break
+
+        self.assertListEqual(sample_sequence, sample_sequence_second)
+
     def testSetOrigin(self):
         # create set of coordinates and localize protocol
         protLocalSubparticles = self._runSubparticles(600, [-177.8, 5.5, 0.5], alignSubParticles=False)

--- a/localrec/utils.py
+++ b/localrec/utils.py
@@ -301,9 +301,17 @@ def filter_subparticles(subparticles, filters):
 
 def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
                         part_image_size, randomize, subparticles_total,
-                        align_subparticles, handness, angpix):
+                        align_subparticles, handness, angpix,
+                        symmetry_group_label=None,
+                        symmetry_operator_ids=None):
     """ Obtain all subparticles from a given particle and set
-    the properties of each such subparticle. """
+    the properties of each such subparticle.
+
+    :param symmetry_group_label: User-selected point group label (for example
+        C2, D7, O, I1) written to _symmetryGroup.
+    :param symmetry_operator_ids: Optional 1-based operator IDs aligned with
+        symmetry_matrices iteration, written to _symmetryOperatorId.
+    """
 
     # Euler angles that take particle to the orientation of the model
     matrix_particle = inv(particle.getTransform().getMatrix())
@@ -312,6 +320,10 @@ def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
     subparticles = []
     subparticles_total += 1
     symmetry_matrix_ids = range(1, len(symmetry_matrices) + 1)
+    if (symmetry_operator_ids is not None and
+            len(symmetry_operator_ids) != len(symmetry_matrices)):
+        raise ValueError("symmetry_operator_ids size must match "
+                         "symmetry_matrices size.")
 
     if randomize:
         # randomize the order of symmetry matrices, prevents preferred views
@@ -324,6 +336,9 @@ def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
             # symmetry_matrix_id can be later written out to find out
             # which symmetry matrix created this subparticle
             symmetry_matrix = np.array(symmetry_matrices[symmetry_matrix_id - 1][0:3, 0:3])
+            symmetry_operator_id = (symmetry_operator_ids[symmetry_matrix_id - 1]
+                                    if symmetry_operator_ids is not None
+                                    else symmetry_matrix_id)
 
             subpart = particle.clone()
             m = np.matmul(matrix_particle[0:3, 0:3], (np.matmul(symmetry_matrix.transpose(),
@@ -370,6 +385,10 @@ def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
                 ctf.setDefocusV(subpart.getCTF().getDefocusV() + z_ang)
 
             subpart.setCoordinate(coord)
+            # group label = user-selected point group.
+            subpart._symmetryGroup = str(symmetry_group_label or "")
+            # operator ID = 1-based index in the full symmetry operator set.
+            subpart._symmetryOperatorId = int(symmetry_operator_id)
             coord._subparticle = subpart.clone()
             subparticles.append(subpart)
 

--- a/localrec/utils.py
+++ b/localrec/utils.py
@@ -299,9 +299,37 @@ def filter_subparticles(subparticles, filters):
             if all(f(subparticles, sp) for f in filters)]
 
 
+def _safe_get_obj_attr_value(obj, attr_name, default=None):
+    """Read an attribute value handling both wrapped and raw values."""
+    if obj is None or not hasattr(obj, attr_name):
+        return default
+
+    value = getattr(obj, attr_name)
+    if hasattr(value, 'get'):
+        try:
+            value = value.get()
+        except Exception:
+            return default
+
+    return value if value is not None else default
+
+
+def get_subparticle_provenance(subparticle, default_group=None, default_operator=None):
+    """Return (symmetry_group, symmetry_operator_id) from a subparticle-like object."""
+    sym_group = _safe_get_obj_attr_value(subparticle, '_symmetryGroup', default_group)
+    operator_id = _safe_get_obj_attr_value(subparticle, '_symmetryOperatorId', default_operator)
+    return sym_group, operator_id
+
+
+def has_subparticle_provenance(subparticle):
+    sym_group, operator_id = get_subparticle_provenance(subparticle)
+    return sym_group is not None and operator_id is not None
+
+
 def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
                         part_image_size, randomize, subparticles_total,
-                        align_subparticles, handness, angpix):
+                        align_subparticles, handness, angpix,
+                        symmetry_operator_ids=None, symmetry_group=None):
     """ Obtain all subparticles from a given particle and set
     the properties of each such subparticle. """
 
@@ -311,7 +339,13 @@ def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
 
     subparticles = []
     subparticles_total += 1
-    symmetry_matrix_ids = range(1, len(symmetry_matrices) + 1)
+    symmetry_matrix_ids = list(range(1, len(symmetry_matrices) + 1))
+    if symmetry_operator_ids is None:
+        symmetry_operator_ids = list(symmetry_matrix_ids)
+    elif len(symmetry_operator_ids) != len(symmetry_matrices):
+        raise ValueError('symmetry_operator_ids length (%d) does not match '
+                         'symmetry_matrices length (%d).'
+                         % (len(symmetry_operator_ids), len(symmetry_matrices)))
 
     if randomize:
         # randomize the order of symmetry matrices, prevents preferred views
@@ -324,6 +358,7 @@ def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
             # symmetry_matrix_id can be later written out to find out
             # which symmetry matrix created this subparticle
             symmetry_matrix = np.array(symmetry_matrices[symmetry_matrix_id - 1][0:3, 0:3])
+            symmetry_operator_id = symmetry_operator_ids[symmetry_matrix_id - 1]
 
             subpart = particle.clone()
             m = np.matmul(matrix_particle[0:3, 0:3], (np.matmul(symmetry_matrix.transpose(),
@@ -370,6 +405,9 @@ def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
                 ctf.setDefocusV(subpart.getCTF().getDefocusV() + z_ang)
 
             subpart.setCoordinate(coord)
+            subpart._symmetryOperatorId = int(symmetry_operator_id)
+            if symmetry_group is not None:
+                subpart._symmetryGroup = int(symmetry_group)
             coord._subparticle = subpart.clone()
             subparticles.append(subpart)
 

--- a/localrec/utils.py
+++ b/localrec/utils.py
@@ -299,7 +299,7 @@ def filter_subparticles(subparticles, filters):
             if all(f(subparticles, sp) for f in filters)]
 
 
-def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
+def create_subparticles(particle, symmetry_matrices_with_ids, subparticle_vector_list,
                         part_image_size, randomize, subparticles_total,
                         align_subparticles, handness, angpix):
     """ Obtain all subparticles from a given particle and set
@@ -311,19 +311,19 @@ def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
 
     subparticles = []
     subparticles_total += 1
-    symmetry_matrix_ids = range(1, len(symmetry_matrices) + 1)
-
+    matrix_items = list(symmetry_matrices_with_ids)
     if randomize:
         # randomize the order of symmetry matrices, prevents preferred views
-        random.shuffle(symmetry_matrix_ids)
+        random.shuffle(matrix_items)
 
     for subparticle_vector in subparticle_vector_list:
         matrix_from_subparticle_vector = subparticle_vector.get_matrix()
 
-        for symmetry_matrix_id in symmetry_matrix_ids:
+        for symmetry_matrix_id, symmetry_matrix in matrix_items:
             # symmetry_matrix_id can be later written out to find out
-            # which symmetry matrix created this subparticle
-            symmetry_matrix = np.array(symmetry_matrices[symmetry_matrix_id - 1][0:3, 0:3])
+            # which symmetry matrix created this subparticle. It must refer to
+            # the original full symmetry-set ID.
+            symmetry_matrix = np.array(symmetry_matrix[0:3, 0:3])
 
             subpart = particle.clone()
             m = np.matmul(matrix_particle[0:3, 0:3], (np.matmul(symmetry_matrix.transpose(),
@@ -370,6 +370,7 @@ def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
                 ctf.setDefocusV(subpart.getCTF().getDefocusV() + z_ang)
 
             subpart.setCoordinate(coord)
+            coord._symmetryOperatorId = symmetry_matrix_id
             coord._subparticle = subpart.clone()
             subparticles.append(subpart)
 


### PR DESCRIPTION
### Motivation
- Ensure consumers of subparticles tolerate missing symmetry provenance and provide stable provenance when creating subparticles, especially when users select subsets of symmetry operators.
- Provide safe helper accessors for reading provenance from subparticle objects in mixed/wrapped environments.
- Expose provenance availability in statistics exports for downstream spatial analyses and add tests to validate provenance behavior.

### Description
- Added helpers in `localrec/utils.py`: `_safe_get_obj_attr_value`, `get_subparticle_provenance`, and `has_subparticle_provenance` to read `_symmetryGroup` and `_symmetryOperatorId` robustly from subparticle-like objects. 
- Extended `create_subparticles` to accept `symmetry_operator_ids` and `symmetry_group`, validate operator mapping length, and persist `_symmetryOperatorId` and `_symmetryGroup` on created subparticles so operator IDs remain stable when `symmetryMatrixIds` subsets are used (`localrec/utils.py`).
- Passed operator IDs and symmetry group from the localized-definition protocol so created subparticles carry original operator provenance (`localrec/protocols/protocol_localized.py`).
- Added non-blocking warnings in consumer protocols when provenance is missing and continue processing (`protocol_localized_extraction.py`, `protocol_filter_subparticles.py`).
- Extended subparticle statistics (`protocol_subparticle_statistics.py`) to count provenance-present/missing items, issue a warning if many are missing, include a `provenance` summary in the JSON, and add provenance columns to CSV outputs.
- Added focused tests in `localrec/tests/test_protocol_localized_reconstruction.py` that assert provenance fields exist, that the symmetry group matches the protocol choice, and that operator IDs are correctly mapped and stable when `symmetryMatrixIds` subsets are used.

### Testing
- Ran `python -m compileall -q localrec` which completed successfully.
- Attempted `python -m pytest -q localrec/tests/test_protocol_localized_reconstruction.py -k provenance` which failed during collection due to a missing external dependency (`ModuleNotFoundError: No module named 'pwem'`) in this environment, preventing execution of the new tests here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c439fb2fa08326a420f3f12f935ac7)