### PR TITLE
Preserve subparticle provenance when extracting coordinates and store symmetry IDs as pwobj.Integer

### DIFF
--- a/localrec/protocols/protocol_extract_coordinates_from_subparticles.py
+++ b/localrec/protocols/protocol_extract_coordinates_from_subparticles.py
@@ -93,12 +93,13 @@ class ProtExtractCoordSubparticles(ProtParticlePicking, ProtParticles):
         # that subparticle coordinates id  are not unique
         # if we join all the sets of subparticle particle coordinates
         for part in inputSubParticlesSet:
-            coor = part.getCoordinate()
+            coor = part.getCoordinate().clone()
             # micid is used to relate particle and subparticle coordinates
             # we just clean the mic name since it is standard practice
             # in other localrec protocols.
             coor.setMicName(None)
             coor.setObjId(idx)
+            coor._subparticle = part.clone()
             outputSet.append(coor)
             idx += 1
 
@@ -127,4 +128,3 @@ class ProtExtractCoordSubparticles(ProtParticlePicking, ProtParticles):
     def _summary(self):
         summary = []
         return summary
-

--- a/localrec/tests/test_protocol_localized_reconstruction.py
+++ b/localrec/tests/test_protocol_localized_reconstruction.py
@@ -254,6 +254,16 @@ class TestLocalizedRecons(TestLocalizedReconsBase):
         coordinate = coordinates.getFirstItem()
         self.assertTrue(coordinate.getObjId() == 1)
         self.assertTrue(coordinate.getMicId() == 1)
+        sym_group, operator_id = self._extract_provenance(coordinate)
+        self.assertIsNotNone(sym_group)
+        self.assertIsNotNone(operator_id)
+
+        for i, coord in enumerate(coordinates.iterItems()):
+            sampled_sym_group, sampled_operator_id = self._extract_provenance(coord)
+            self.assertIsNotNone(sampled_sym_group)
+            self.assertIsNotNone(sampled_operator_id)
+            if i >= 20:
+                break
 
     def _extract_provenance(self, coord):
         return get_subparticle_provenance(coord._subparticle)

--- a/localrec/utils.py
+++ b/localrec/utils.py
@@ -40,6 +40,7 @@ from pwem.convert.transformations import (vector_norm, unit_vector,
 from pwem.objects.data import Coordinate
 import pwem as em
 import pyworkflow.utils as pwutils
+import pyworkflow.object as pwobj
 from pyworkflow import SCIPION_DEBUG_NOCLEAN
 
 
@@ -412,9 +413,9 @@ def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
                 ctf.setDefocusV(subpart.getCTF().getDefocusV() + z_ang)
 
             subpart.setCoordinate(coord)
-            subpart._symmetryOperatorId = int(symmetry_operator_id)
+            subpart._symmetryOperatorId = pwobj.Integer(int(symmetry_operator_id))
             if symmetry_group is not None:
-                subpart._symmetryGroup = int(symmetry_group)
+                subpart._symmetryGroup = pwobj.Integer(int(symmetry_group))
             coord._subparticle = subpart.clone()
             subparticles.append(subpart)
 


### PR DESCRIPTION
### Motivation
- Ensure subparticle provenance is preserved when building a combined coordinates set so downstream code can recover the original subparticle and its symmetry/operator metadata. 
- Make symmetry metadata stored on subparticle objects use persistent `pyworkflow.object.Integer` wrappers instead of plain `int` to ensure correct object semantics.
- Add tests to validate that provenance extraction returns non-null symmetry group and operator ids for extracted coordinates.

### Description
- In `ProtExtractCoordSubparticles.createOutputStep` clone each particle coordinate via `part.getCoordinate().clone()` and attach a cloned subparticle to `coor._subparticle` so provenance travels with the coordinate. 
- Keep coordinates unique by setting `coor.setObjId(idx)` and clear micrograph name via `coor.setMicName(None)` when building the output set. 
- In `localrec.utils.create_subparticles` import `pyworkflow.object as pwobj` and set `subpart._symmetryOperatorId` and `subpart._symmetryGroup` using `pwobj.Integer(int(...))` instead of raw `int`. 
- Update `localrec/tests/test_protocol_localized_reconstruction.py` to assert provenance via a helper `_extract_provenance` that calls `get_subparticle_provenance(coord._subparticle)`, checking the first coordinate and sampling up to 20 coordinates for non-null symmetry group and operator id.

### Testing
- Ran the unit tests in `localrec/tests/test_protocol_localized_reconstruction.py` that exercise `ProtExtractCoordSubparticles` and the provenance assertions, and they passed. 
- Executed the modified `TestLocalizedRecons` provenance checks which succeeded for the sampled coordinates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4471734308326880f61cb24b3a6f0)