### PR TITLE
Remove deprecated euler2matrix helper and imports

### DIFF
--- a/localrec/protocols/protocol_localized_stitch_models.py
+++ b/localrec/protocols/protocol_localized_stitch_models.py
@@ -46,7 +46,7 @@ from pwem.constants import (SYM_CYCLIC, SYM_DIHEDRAL, SYM_OCTAHEDRAL,
                             SYM_I2n3, SYM_I2n3r, SYM_I2n5, SYM_I2n5r, SYM_DIHEDRAL_X, SYM_DIHEDRAL_Y)
 
 from localrec.constants import CMM
-from localrec.utils import euler2matrix,distances_from_string, generate_chain_id, load_vectors, pdbIds_from_string, vectors_from_cmm, vectors_from_string
+from localrec.utils import distances_from_string, generate_chain_id, load_vectors, pdbIds_from_string, vectors_from_cmm, vectors_from_string
 
 
 

--- a/localrec/utils.py
+++ b/localrec/utils.py
@@ -112,30 +112,6 @@ def matrixFromGeometry(shifts, angles, inverseTransform):
 
     return M
 
-def euler2matrix(rot, tilt, psi):
-    mtrix = np.zeros((3,3), dtype=float)
-    ca = np.cos(np.degrees(rot))
-    sa = np.sin(np.degrees(rot))
-    cb = np.cos(np.degrees(tilt))
-    sb = np.sin(np.degrees(tilt))
-    cg = np.cos(np.degrees(psi))
-    sg = np.sin(np.degrees(psi))
-
-    cc = cb * ca
-    cs = cb * sa
-    sc = sb * ca
-    ss = sb * sa
-
-    mtrix[0, 0] =  cg * cc - sg * sa
-    mtrix[0, 1] =  cg * cs + sg * ca
-    mtrix[0, 2] = -cg * sb
-    mtrix[1, 0] = -sg * cc - cg * sa
-    mtrix[1, 1] = -sg * cs + cg * ca
-    mtrix[1, 2] = sg * sb
-    mtrix[2, 0] =  sc
-    mtrix[2, 1] =  ss
-    mtrix[2, 2] = cb
-    return mtrix
 def load_vectors(cmm_file, vectors_str, distances_str, angpix):
     """ Load subparticle vectors either from Chimera CMM file or from
     a vectors string. Distances can also be specified for each vector


### PR DESCRIPTION
### Motivation
- The codebase uses `pwem` transformation utilities and the local `euler2matrix` helper is redundant and inconsistent with the plugin convention `euler_matrix(..., 'szyz')`, so it should be removed to avoid duplication and maintenance cost.

### Description
- Deleted the `euler2matrix(rot, tilt, psi)` function from `localrec/utils.py` and left `matrixFromGeometry` and other utilities relying on `pwem.convert.transformations` intact.
- Removed `euler2matrix` from the import list in `localrec/protocols/protocol_localized_stitch_models.py` so callers use the existing `pwem` conversion utilities when needed.
- Confirmed there are no remaining references to `euler2matrix` across the repository; any replacement callers should use `pwem.convert.transformations.euler_matrix(..., 'szyz')` to match existing conventions.

### Testing
- Ran a repository search with `rg -n "euler2matrix" . || true` and confirmed there are no matches (success).
- Inspected the modified files to ensure imports and definitions were updated and no lingering references remain (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c55f37acd083269c86e7d018c0ee99)