### PR TITLE
Make Vector3.compute_matrix robust and add unit tests for vector-matrix alignment

### DIFF
--- a/localrec/tests/test_utils_vector_matrix.py
+++ b/localrec/tests/test_utils_vector_matrix.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# **************************************************************************
+# *
+# * Authors: LocalRec maintainers
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# **************************************************************************
+
+import unittest
+import numpy as np
+
+from localrec.utils import Vector3, load_vectors
+
+
+class TestVectorMatrix(unittest.TestCase):
+    def _assertVectorAlignedToMatrixZ(self, vector):
+        v = Vector3()
+        v.set_vector(vector)
+        v.compute_unit_vector()
+        v.compute_matrix()
+        mat = v.get_matrix()
+        # Third column is rotated Z axis.
+        rotated_z = mat[:, 2]
+        np.testing.assert_allclose(rotated_z, v.vector, atol=1e-7)
+
+    def testVectorAlignmentPositiveX(self):
+        self._assertVectorAlignedToMatrixZ([1.0, 0.0, 0.0])
+
+    def testVectorAlignmentNegativeX(self):
+        self._assertVectorAlignedToMatrixZ([-1.0, 0.0, 0.0])
+
+    def testLoadVectorsNegativeXWithAndWithoutAlternativeLength(self):
+        no_alt = load_vectors("", "-1,0,0", "0", 1.0)[0]
+        with_alt = load_vectors("", "-1,0,0", "5", 1.0)[0]
+
+        np.testing.assert_allclose(no_alt.vector, np.array([-1.0, 0.0, 0.0]), atol=1e-7)
+        np.testing.assert_allclose(with_alt.vector, np.array([-1.0, 0.0, 0.0]), atol=1e-7)
+        self.assertAlmostEqual(no_alt.get_length(), 1.0, places=7)
+        self.assertAlmostEqual(with_alt.get_length(), 5.0, places=7)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/localrec/utils.py
+++ b/localrec/utils.py
@@ -69,17 +69,41 @@ class Vector3:
         self.set_vector(unit_vector(self.vector))
 
     def compute_matrix(self):
-        """ Compute rotation matrix to align Z axis to this vector. """
+        """Compute rotation matrix to align Z axis to this vector.
 
-        if abs(self.vector[0]) < 0.00001 and abs(self.vector[1]) < 0.00001:
-            rot = math.radians(0.00)
-            tilt = math.radians(0.00)
+        Build a stable rotation directly from vectors instead of Euler-angle
+        decomposition to avoid convention ambiguities around antiparallel
+        vectors (for example [-1, 0, 0]).
+        """
+        # Make sure we operate on a normalized vector.
+        v = np.array(self.vector, dtype=float)
+        v_norm = vector_norm(v)
+        if v_norm < 1e-12:
+            raise ValueError("Cannot compute rotation matrix for zero vector.")
+        v /= v_norm
+
+        z_axis = np.array([0.0, 0.0, 1.0], dtype=float)
+        dot = np.clip(np.dot(z_axis, v), -1.0, 1.0)
+        eps = 1e-10
+
+        if dot > 1.0 - eps:
+            rot = np.identity(3, dtype=float)
+        elif dot < -1.0 + eps:
+            # 180 deg rotation around a deterministic axis orthogonal to Z.
+            # Rotate around X: Z -> -Z.
+            rot = np.array([[1.0, 0.0, 0.0],
+                            [0.0, -1.0, 0.0],
+                            [0.0, 0.0, -1.0]], dtype=float)
         else:
-            rot = math.atan2(self.vector[1], self.vector[0])
-            tilt = math.acos(self.vector[2])
+            axis = np.cross(z_axis, v)
+            s = vector_norm(axis)
+            k = np.array([[0.0, -axis[2], axis[1]],
+                          [axis[2], 0.0, -axis[0]],
+                          [-axis[1], axis[0], 0.0]], dtype=float)
+            rot = np.identity(3, dtype=float) + k + np.matmul(k, k) * ((1.0 - dot) / (s ** 2))
 
-        psi = 0
-        self.matrix = euler_matrix(-rot, -tilt, -psi, 'szyz')
+        self.matrix = np.identity(4, dtype=float)
+        self.matrix[0:3, 0:3] = rot
 
     def print_vector(self):
         print("[%.3f,%.3f,%.3f]" % (self.vector[0], self.vector[1], self.vector[2]))


### PR DESCRIPTION
### Motivation

- Replace an Euler-angle based rotation construction that produced ambiguous results for antiparallel vectors with a stable vector-based rotation to reliably align the Z axis to any given vector.
- Ensure deterministic behavior for edge cases like vectors pointing exactly opposite to Z and reject zero-length vectors.
- Add unit tests to verify the matrix alignment and the `load_vectors` length behavior.

### Description

- Rewrote `Vector3.compute_matrix` to build the rotation directly from vectors using cross products and the Rodrigues-style formula, handling `dot` ≈ ±1 as special cases and normalizing the input vector first.
- Added a guard that raises `ValueError` when attempting to compute a rotation for a zero vector.
- Updated the 4x4 `matrix` storage so the computed 3x3 rotation is assigned into the top-left block unchanged after computation.
- Added new unit tests in `localrec/tests/test_utils_vector_matrix.py` that assert the third column of the rotation equals the unit vector for several cases and that `load_vectors` respects the alternative length parameter.

### Testing

- Ran the new unit test file with `python -m unittest localrec.tests.test_utils_vector_matrix` and the tests passed.
- The added tests exercise positive and negative X vectors and the `load_vectors` length behavior and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e74235a4848326a114a636bc604f56)