### PR TITLE
Simplify particle half-dimension calculation in localized extraction

### DIFF
--- a/localrec/protocols/protocol_localized_extraction.py
+++ b/localrec/protocols/protocol_localized_extraction.py
@@ -130,8 +130,7 @@ class ProtLocalizedExtraction(ProtParticles):
             outputSet.setSamplingRate(outputSampling)
 
         boxSize = self.boxSize.get()
-        halfParticleXDim = inputParticles.getXDim() / 2.0
-        halfParticleYDim = inputParticles.getYDim() / 2.0
+        halfParticleDim = inputParticles.getXDim() / 2.0
         center = np.zeros((boxSize, boxSize))
 
         ih = ImageHandler()
@@ -200,8 +199,8 @@ class ProtLocalizedExtraction(ProtParticles):
                         continue
                     particle = inputParticles[partId]
                     particleCoord = particle.getCoordinate()
-                    xOffset = coord.getX() - halfParticleXDim
-                    yOffset = coord.getY() - halfParticleYDim
+                    xOffset = coord.getX() - halfParticleDim
+                    yOffset = coord.getY() - halfParticleDim
                     xpos, ypos = self._computeMicrographCropCenter(
                         particleCoord.getX(), particleCoord.getY(),
                         xOffset, yOffset, coordMicSampling, particleSampling,


### PR DESCRIPTION
### Motivation
- Simplify offset computation by using a single half-particle dimension (assuming a square particle box) and remove redundant per-axis variables.

### Description
- Replace `halfParticleXDim` and `halfParticleYDim` with a single `halfParticleDim = inputParticles.getXDim() / 2.0` and use it for both `xOffset` and `yOffset` in the localized extraction logic.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a279543c74c83269c78d2799a7e2aea)