### PR TITLE
Set output particle dimensions early and validate first extracted subparticle

### DIFF
--- a/localrec/protocols/protocol_localized_extraction.py
+++ b/localrec/protocols/protocol_localized_extraction.py
@@ -130,12 +130,14 @@ class ProtLocalizedExtraction(ProtParticles):
             outputSet.setSamplingRate(outputSampling)
 
         boxSize = self.boxSize.get()
+        self._setOutputSetDimensions(outputSet, boxSize)
         halfParticleDim = inputParticles.getXDim() / 2.0
         center = np.zeros((boxSize, boxSize))
 
         ih = ImageHandler()
 
-        i = 0
+        outIndex = 0
+        firstOutputValidated = False
         discardedOutliers = 0
         paddedOutliers = 0
         partIdExcluded = []
@@ -146,10 +148,10 @@ class ProtLocalizedExtraction(ProtParticles):
         progress = ProgressBar(len(inputCoords), fmt=ProgressBar.NOBAR)
         progress.start()
         step = max(100, len(inputCoords) // 100)
-        for i, coord in enumerate(inputCoords.iterItems(orderBy=['_subparticle._micId',
-                                                    '_micId', 'id'])):
-            if i % step == 0:
-                progress.update(i+1)
+        for coordIndex, coord in enumerate(inputCoords.iterItems(
+                orderBy=['_subparticle._micId', '_micId', 'id'])):
+            if coordIndex % step == 0:
+                progress.update(coordIndex + 1)
 
             # The original particle id is stored in the sub-particle as micId
             partId = coord._micId.get()
@@ -226,8 +228,12 @@ class ProtLocalizedExtraction(ProtParticles):
 
                 center[:, :] = centerData
                 outputImg.setData(center)
-                i += 1
-                outputImg.write((i, outputStack))
+                outIndex += 1
+                outputImg.write((outIndex, outputStack))
+                if not firstOutputValidated:
+                    self._validateWrittenOutputImage(ih, outputStack, outIndex,
+                                                     boxSize)
+                    firstOutputValidated = True
                 subpart = coord._subparticle
                 if (not missingProvenanceWarned and
                         not has_subparticle_provenance(subpart)):
@@ -241,9 +247,9 @@ class ProtLocalizedExtraction(ProtParticles):
                     self._scaleSubparticleOriginShift(
                         subpart, particleSampling / outputSampling)
                 subpart.setLocation(
-                    (i, outputStack))  # Change path to new stack
-                # Ids will be always the same no matter the number of outliers.
-                subpart.setObjId(i)
+                    (outIndex, outputStack))  # Change path to new stack
+                # Ids will be always contiguous despite skipped outliers.
+                subpart.setObjId(outIndex)
                 outputSet.append(subpart)
 
         progress.finish()
@@ -258,6 +264,53 @@ class ProtLocalizedExtraction(ProtParticles):
         outputSet.setIsSubparticles(True)
         self._defineOutputs(**{self.OUTPUTPARTICLESNAME: outputSet})
         self._defineSourceRelation(self.inputParticles, outputSet)
+
+
+    @staticmethod
+    def _setOutputSetDimensions(outputSet, boxSize):
+        """Set output particle dimensions without reading the first item.
+
+        Localized extraction can emit subparticles with a box size that differs
+        from the parent particles.  Record those dimensions eagerly so Scipion
+        does not need to infer them by opening the first output stack item while
+        the set is being defined.
+        """
+        boxDim = (boxSize, boxSize, 1)
+
+        if hasattr(outputSet, 'setDim'):
+            outputSet.setDim(boxDim)
+            return
+
+        if hasattr(outputSet, 'setDimensions'):
+            outputSet.setDimensions(boxDim)
+            return
+
+        dimensions = getattr(outputSet, '_dimensions', None)
+        if dimensions is not None:
+            dimText = '%d %d %d' % boxDim
+            if hasattr(dimensions, 'set'):
+                dimensions.set(dimText)
+            else:
+                outputSet._dimensions = dimText
+
+    @staticmethod
+    def _validateWrittenOutputImage(ih, outputStack, outIndex, boxSize):
+        """Ensure the first written subparticle can be read as boxSize x boxSize."""
+        location = (outIndex, outputStack)
+        try:
+            img = ih.read(location)
+        except Exception as exc:
+            raise RuntimeError(
+                'Could not read the first extracted subparticle from %s at '
+                'index %d; expected a %dx%d image.'
+                % (outputStack, outIndex, boxSize, boxSize)) from exc
+
+        xDim, yDim, _, _ = img.getDimensions()
+        if xDim != boxSize or yDim != boxSize:
+            raise RuntimeError(
+                'First extracted subparticle in %s at index %d has dimensions '
+                '%dx%d, but expected %dx%d.'
+                % (outputStack, outIndex, xDim, yDim, boxSize, boxSize))
 
     @staticmethod
     def _getSamplingRate(itemSet):

--- a/localrec/tests/test_protocol_localized_extraction_scaling.py
+++ b/localrec/tests/test_protocol_localized_extraction_scaling.py
@@ -58,6 +58,71 @@ class TestLocalizedExtractionScaling(unittest.TestCase):
         self.assertEqual(downsampled.shape, (4, 4))
         np.testing.assert_allclose(downsampled, 7, rtol=1e-6)
 
+    def test_output_set_dimensions_uses_set_dim(self):
+        class DummySet:
+            def __init__(self):
+                self.dim = None
+
+            def setDim(self, dim):
+                self.dim = dim
+
+        outputSet = DummySet()
+
+        ProtLocalizedExtraction._setOutputSetDimensions(outputSet, 26)
+
+        self.assertEqual(outputSet.dim, (26, 26, 1))
+
+    def test_output_set_dimensions_falls_back_to_dimensions_attribute(self):
+        class DummyDimensions:
+            def __init__(self):
+                self.value = None
+
+            def set(self, value):
+                self.value = value
+
+        class DummySet:
+            def __init__(self):
+                self._dimensions = DummyDimensions()
+
+        outputSet = DummySet()
+
+        ProtLocalizedExtraction._setOutputSetDimensions(outputSet, 26)
+
+        self.assertEqual(outputSet._dimensions.value, '26 26 1')
+
+    def test_validate_written_output_image_accepts_matching_dimensions(self):
+        class DummyImage:
+            def getDimensions(self):
+                return 26, 26, 1, 1
+
+        class DummyImageHandler:
+            def __init__(self):
+                self.location = None
+
+            def read(self, location):
+                self.location = location
+                return DummyImage()
+
+        ih = DummyImageHandler()
+
+        ProtLocalizedExtraction._validateWrittenOutputImage(
+            ih, 'particles.mrcs', 1, 26)
+
+        self.assertEqual(ih.location, (1, 'particles.mrcs'))
+
+    def test_validate_written_output_image_rejects_bad_dimensions(self):
+        class DummyImage:
+            def getDimensions(self):
+                return 24, 24, 1, 1
+
+        class DummyImageHandler:
+            def read(self, location):
+                return DummyImage()
+
+        with self.assertRaisesRegex(RuntimeError, 'expected 26x26'):
+            ProtLocalizedExtraction._validateWrittenOutputImage(
+                DummyImageHandler(), 'particles.mrcs', 1, 26)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Motivation

- Localized extraction can produce subparticles with box sizes that differ from their parent particles, and Scipion may otherwise try to infer dimensions by opening the first output image which is undesirable during set definition. 
- Ensure output ids are contiguous and that the first written subparticle actually has the expected box dimensions to catch writing/formatting errors early.

### Description

- Record the output particle dimensions eagerly by adding `ProtLocalizedExtraction._setOutputSetDimensions(outputSet, boxSize)` and implement `_setOutputSetDimensions` to support `setDim`, `setDimensions`, and the `_dimensions` attribute fallback. 
- Replace loop counters with clearer names (`coordIndex`, `outIndex`) and make written subparticle object ids contiguous by using `outIndex` for `setLocation` and `setObjId`.
- Validate the first written subparticle by adding `_validateWrittenOutputImage` which reads the first written image via the `ImageHandler` and checks its `getDimensions()` against the expected `boxSize`, raising a `RuntimeError` if it cannot be read or the dimensions mismatch.
- Added unit tests covering ` _setOutputSetDimensions` behaviors and `_validateWrittenOutputImage` success and failure cases in `localrec/tests/test_protocol_localized_extraction_scaling.py`.

### Testing

- Ran the localized extraction unit tests including `localrec/tests/test_protocol_localized_extraction_scaling.py` which exercise the new `_setOutputSetDimensions` and `_validateWrittenOutputImage` behaviors. All added and existing unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2798e8dca0832683b00c795d97b9b0)