### PR TITLE
Sanitize cloned micrograph coordinates and clone nested subparticles during extraction

### DIFF
--- a/localrec/protocols/protocol_localized_extraction.py
+++ b/localrec/protocols/protocol_localized_extraction.py
@@ -234,7 +234,7 @@ class ProtLocalizedExtraction(ProtParticles):
                     self._validateWrittenOutputImage(ih, outputStack, outIndex,
                                                      boxSize)
                     firstOutputValidated = True
-                subpart = coord._subparticle
+                subpart = coord._subparticle.clone()
                 if (not missingProvenanceWarned and
                         not has_subparticle_provenance(subpart)):
                     self.warning("Subparticle provenance fields "
@@ -385,6 +385,7 @@ class ProtLocalizedExtraction(ProtParticles):
                                    parentParticleId):
         """Clone a coordinate and set it in source-micrograph coordinates."""
         outputCoord = coord.clone()
+        ProtLocalizedExtraction._sanitizeOutputCoordinate(outputCoord)
         outputCoord.setX(xpos)
         outputCoord.setY(ypos)
         outputCoord.setMicId(particleCoord.getMicId())
@@ -396,6 +397,19 @@ class ProtLocalizedExtraction(ProtParticles):
         else:
             outputCoord._parentParticleId = parentParticleId
         return outputCoord
+
+    @staticmethod
+    def _sanitizeOutputCoordinate(coord):
+        """Remove localized-coordinate payloads before storing in a particle.
+
+        Coordinates produced by localized reconstruction carry the source
+        subparticle in ``_subparticle``.  Keeping that nested particle inside the
+        coordinate of an extracted output particle causes Scipion's SQLite mapper
+        to see many more fields than the output SetOfParticles schema contains.
+        """
+        if hasattr(coord, '_subparticle'):
+            delattr(coord, '_subparticle')
+        return coord
 
     @staticmethod
     def _scaleSubparticleOriginShift(subpart, scale):

--- a/localrec/tests/test_protocol_localized_extraction_scaling.py
+++ b/localrec/tests/test_protocol_localized_extraction_scaling.py
@@ -123,6 +123,73 @@ class TestLocalizedExtractionScaling(unittest.TestCase):
             ProtLocalizedExtraction._validateWrittenOutputImage(
                 DummyImageHandler(), 'particles.mrcs', 1, 26)
 
+    def test_clone_micrograph_coordinate_removes_nested_subparticle(self):
+        class DummyValue:
+            def __init__(self, value):
+                self.value = value
+
+            def clone(self):
+                return DummyValue(self.value)
+
+            def get(self):
+                return self.value
+
+        class DummyCoordinate:
+            def __init__(self):
+                self.x = None
+                self.y = None
+                self.micId = None
+                self.micName = None
+                self._micId = DummyValue(7)
+                self._subparticle = object()
+
+            def clone(self):
+                clone = DummyCoordinate()
+                clone._micId = self._micId
+                clone._subparticle = self._subparticle
+                return clone
+
+            def setX(self, value):
+                self.x = value
+
+            def setY(self, value):
+                self.y = value
+
+            def setMicId(self, value):
+                self.micId = value
+
+            def setMicName(self, value):
+                self.micName = value
+
+        class DummyParticleCoordinate:
+            def getMicId(self):
+                return 3
+
+            def getMicName(self):
+                return 'mic-a'
+
+        outputCoord = ProtLocalizedExtraction._cloneMicrographCoordinate(
+            DummyCoordinate(), DummyParticleCoordinate(), 11, 13, 7)
+
+        self.assertFalse(hasattr(outputCoord, '_subparticle'))
+        self.assertEqual(outputCoord.x, 11)
+        self.assertEqual(outputCoord.y, 13)
+        self.assertEqual(outputCoord.micId, 3)
+        self.assertEqual(outputCoord.micName, 'mic-a')
+        self.assertEqual(outputCoord._parentParticleId.get(), 7)
+
+    def test_sanitize_output_coordinate_returns_coordinate(self):
+        class DummyCoordinate:
+            pass
+
+        coord = DummyCoordinate()
+        coord._subparticle = object()
+
+        sanitized = ProtLocalizedExtraction._sanitizeOutputCoordinate(coord)
+
+        self.assertIs(sanitized, coord)
+        self.assertFalse(hasattr(coord, '_subparticle'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Motivation

- Prevent nested subparticle payloads from being stored inside extracted particle coordinates which causes the SQLite mapper to see unexpected fields and break schema expectations.  
- Avoid mutating original subparticle objects by cloning them when building output particle entries.

### Description

- Added `ProtLocalizedExtraction._sanitizeOutputCoordinate` to remove the `_subparticle` attribute from coordinates before they are stored.  
- Call `ProtLocalizedExtraction._sanitizeOutputCoordinate` from `ProtLocalizedExtraction._cloneMicrographCoordinate`.  
- Change extraction code to use `coord._subparticle.clone()` when assigning `subpart` so the original subparticle is not mutated.  
- Added tests `test_clone_micrograph_coordinate_removes_nested_subparticle` and `test_sanitize_output_coordinate_returns_coordinate` in `localrec/tests/test_protocol_localized_extraction_scaling.py` to validate the new behavior.

### Testing

- Ran the localized extraction unit tests in `localrec/tests/test_protocol_localized_extraction_scaling.py` including the new tests, and they passed.  
- Existing `test_validate_written_output_image` tests were retained and still pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a279d311414832696405fbde1c7cdb2)