### PR TITLE
Preserve parent micrograph grid for displayed subparticle coordinates in localized extraction

### DIFF
--- a/localrec/protocols/protocol_localized_extraction.py
+++ b/localrec/protocols/protocol_localized_extraction.py
@@ -203,16 +203,16 @@ class ProtLocalizedExtraction(ProtParticles):
                     particleCoord = particle.getCoordinate()
                     xOffset = coord.getX() - halfParticleDim
                     yOffset = coord.getY() - halfParticleDim
-                    xpos, ypos = self._computeMicrographCropCenter(
+                    cropX, cropY = self._computeMicrographCropCenter(
                         particleCoord.getX(), particleCoord.getY(),
                         xOffset, yOffset, coordMicSampling, particleSampling,
                         outputSampling)
-                    outputX, outputY = self._computeMicrographCropCenter(
+                    displayX, displayY = self._computeMicrographDisplayCenter(
                         particleCoord.getX(), particleCoord.getY(),
-                        xOffset, yOffset, coordMicSampling, particleSampling,
-                        micSampling)
+                        xOffset, yOffset, coordMicSampling, particleSampling)
                     outputCoord = self._cloneMicrographCoordinate(
-                        coord, particleCoord, outputX, outputY, partId)
+                        coord, particleCoord, displayX, displayY, partId)
+                    xpos, ypos = cropX, cropY
                 else:
                     xpos = coord.getX()
                     ypos = coord.getY()
@@ -342,6 +342,22 @@ class ProtLocalizedExtraction(ProtParticles):
         ypos = (particleY * coordMicSampling / outputSampling +
                 yOffset * particleSampling / outputSampling)
         return int(round(xpos)), int(round(ypos))
+
+    @classmethod
+    def _computeMicrographDisplayCenter(cls, particleX, particleY, xOffset,
+                                        yOffset, coordMicSampling,
+                                        particleSampling):
+        """Return subparticle coordinates in the parent micrograph grid.
+
+        Extracted subparticles keep the parent particles' micrograph linkage,
+        so stored coordinates must use the same micrograph grid as the parent
+        coordinates.  This prevents display coordinates from being multiplied
+        by the original full-resolution micrograph sampling when extraction is
+        performed on an internally downsampled micrograph.
+        """
+        return cls._computeMicrographCropCenter(
+            particleX, particleY, xOffset, yOffset, coordMicSampling,
+            particleSampling, coordMicSampling)
 
     def _getParticleCoordinateMicSampling(self, inputParticles,
                                           inputMicrographs):

--- a/localrec/tests/test_protocol_localized_extraction_scaling.py
+++ b/localrec/tests/test_protocol_localized_extraction_scaling.py
@@ -49,6 +49,27 @@ class TestLocalizedExtractionScaling(unittest.TestCase):
 
         self.assertEqual((xpos, ypos), (55, 94))
 
+    def test_display_center_keeps_parent_micrograph_grid(self):
+        # Parent particles and extracted subparticles are both downsampled 2x.
+        # Display coordinates must stay in the parent/downsampled coordinate
+        # grid instead of being expanded back onto the full-resolution mic grid.
+        cropX, cropY = ProtLocalizedExtraction._computeMicrographCropCenter(
+            particleX=100, particleY=200, xOffset=5, yOffset=-6,
+            coordMicSampling=2.0, particleSampling=2.0,
+            outputSampling=2.0)
+        displayX, displayY = (
+            ProtLocalizedExtraction._computeMicrographDisplayCenter(
+                particleX=100, particleY=200, xOffset=5, yOffset=-6,
+                coordMicSampling=2.0, particleSampling=2.0))
+        fullResX, fullResY = ProtLocalizedExtraction._computeMicrographCropCenter(
+            particleX=100, particleY=200, xOffset=5, yOffset=-6,
+            coordMicSampling=2.0, particleSampling=2.0,
+            outputSampling=1.0)
+
+        self.assertEqual((cropX, cropY), (105, 194))
+        self.assertEqual((displayX, displayY), (105, 194))
+        self.assertEqual((fullResX, fullResY), (210, 388))
+
     def test_fourier_downsampling_preserves_constant_micrograph_level(self):
         data = np.ones((8, 8), dtype=np.float32) * 7
 


### PR DESCRIPTION
### Motivation
- Prevent display coordinates for extracted subparticles from being scaled to the full-resolution micrograph grid when extraction is performed on downsampled micrographs.
- Ensure stored/displayed coordinates remain in the same micrograph sampling grid as their parent particles so provenance and visualization stay consistent.

### Description
- Added a new helper ` _computeMicrographDisplayCenter` which returns subparticle coordinates in the parent micrograph grid by invoking ` _computeMicrographCropCenter` with `outputSampling` set to the parent micrograph sampling.
- Updated extraction logic to compute separate crop center (`cropX`, `cropY`) for the extraction window and display center (`displayX`, `displayY`) for the cloned coordinate, and to use the crop center for the actual pixel extraction (`xpos`, `ypos`).
- Renamed a few local variables to clarify intent (`outputX/outputY` -> `displayX/displayY`) and wired the correct values into `_cloneMicrographCoordinate`.
- Added `test_display_center_keeps_parent_micrograph_grid` to `localrec/tests/test_protocol_localized_extraction_scaling.py` to assert that crop, display, and full-resolution centers behave as intended.

### Testing
- Ran `pytest localrec/tests/test_protocol_localized_extraction_scaling.py` which includes the new `test_display_center_keeps_parent_micrograph_grid` and existing scaling/downsampling tests, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27bac836048326b051803ebb355cb2)