### PR TITLE
Compute display coordinates in source micrograph sampling for localized extraction

### DIFF
--- a/localrec/protocols/protocol_localized_extraction.py
+++ b/localrec/protocols/protocol_localized_extraction.py
@@ -209,7 +209,8 @@ class ProtLocalizedExtraction(ProtParticles):
                         outputSampling)
                     displayX, displayY = self._computeMicrographDisplayCenter(
                         particleCoord.getX(), particleCoord.getY(),
-                        xOffset, yOffset, coordMicSampling, particleSampling)
+                        xOffset, yOffset, coordMicSampling, particleSampling,
+                        micSampling)
                     outputCoord = self._cloneMicrographCoordinate(
                         coord, particleCoord, displayX, displayY, partId)
                     xpos, ypos = cropX, cropY
@@ -346,18 +347,19 @@ class ProtLocalizedExtraction(ProtParticles):
     @classmethod
     def _computeMicrographDisplayCenter(cls, particleX, particleY, xOffset,
                                         yOffset, coordMicSampling,
-                                        particleSampling):
-        """Return subparticle coordinates in the parent micrograph grid.
+                                        particleSampling, micSampling):
+        """Return subparticle coordinates in the source micrograph grid.
 
-        Extracted subparticles keep the parent particles' micrograph linkage,
-        so stored coordinates must use the same micrograph grid as the parent
-        coordinates.  This prevents display coordinates from being multiplied
-        by the original full-resolution micrograph sampling when extraction is
-        performed on an internally downsampled micrograph.
+        Extraction may downsample the micrograph internally, but the coordinate
+        stored in the output subparticle must remain suitable for displaying on
+        the original source micrograph.  Therefore both the micrograph sampling
+        used by the parent particle coordinates and the parent-particle sampling
+        are converted to the provided source micrograph sampling, while the
+        extraction-only downsampling factor is intentionally ignored here.
         """
         return cls._computeMicrographCropCenter(
             particleX, particleY, xOffset, yOffset, coordMicSampling,
-            particleSampling, coordMicSampling)
+            particleSampling, micSampling)
 
     def _getParticleCoordinateMicSampling(self, inputParticles,
                                           inputMicrographs):

--- a/localrec/tests/test_protocol_localized_extraction_scaling.py
+++ b/localrec/tests/test_protocol_localized_extraction_scaling.py
@@ -49,10 +49,11 @@ class TestLocalizedExtractionScaling(unittest.TestCase):
 
         self.assertEqual((xpos, ypos), (55, 94))
 
-    def test_display_center_keeps_parent_micrograph_grid(self):
-        # Parent particles and extracted subparticles are both downsampled 2x.
-        # Display coordinates must stay in the parent/downsampled coordinate
-        # grid instead of being expanded back onto the full-resolution mic grid.
+    def test_display_center_uses_source_micrograph_grid(self):
+        # Parent particles and extracted subparticles are both downsampled 2x for
+        # extraction.  The stored coordinate is used for viewing on the original
+        # source micrograph, so it must not stay in the internally downsampled
+        # extraction grid.
         cropX, cropY = ProtLocalizedExtraction._computeMicrographCropCenter(
             particleX=100, particleY=200, xOffset=5, yOffset=-6,
             coordMicSampling=2.0, particleSampling=2.0,
@@ -60,15 +61,20 @@ class TestLocalizedExtractionScaling(unittest.TestCase):
         displayX, displayY = (
             ProtLocalizedExtraction._computeMicrographDisplayCenter(
                 particleX=100, particleY=200, xOffset=5, yOffset=-6,
-                coordMicSampling=2.0, particleSampling=2.0))
-        fullResX, fullResY = ProtLocalizedExtraction._computeMicrographCropCenter(
-            particleX=100, particleY=200, xOffset=5, yOffset=-6,
-            coordMicSampling=2.0, particleSampling=2.0,
-            outputSampling=1.0)
+                coordMicSampling=2.0, particleSampling=2.0,
+                micSampling=1.0))
 
         self.assertEqual((cropX, cropY), (105, 194))
-        self.assertEqual((displayX, displayY), (105, 194))
-        self.assertEqual((fullResX, fullResY), (210, 388))
+        self.assertEqual((displayX, displayY), (210, 388))
+
+    def test_display_center_ignores_extraction_downsampling_only(self):
+        displayX, displayY = (
+            ProtLocalizedExtraction._computeMicrographDisplayCenter(
+                particleX=100, particleY=200, xOffset=5, yOffset=-6,
+                coordMicSampling=1.0, particleSampling=2.0,
+                micSampling=1.0))
+
+        self.assertEqual((displayX, displayY), (110, 188))
 
     def test_fourier_downsampling_preserves_constant_micrograph_level(self):
         data = np.ones((8, 8), dtype=np.float32) * 7


### PR DESCRIPTION
### Motivation
- Fix incorrect display coordinates when extraction uses internal downsampling so stored subparticle coordinates are suitable for viewing on the original source micrograph.
- Preserve existing crop-center behavior used for extraction while ensuring display coordinates are converted to the source micrograph sampling.
- Make the intent explicit in code and tests so extraction-only downsampling does not affect displayed coordinates.

### Description
- Change `_computeMicrographDisplayCenter` signature to accept `micSampling` and update its docstring to state that display coordinates are computed in the source micrograph grid and ignore extraction-only downsampling.
- Adjust the call site in the extraction loop to pass `micSampling` into `_computeMicrographDisplayCenter`.
- Update unit tests in `localrec/tests/test_protocol_localized_extraction_scaling.py` to assert the new behavior and add `test_display_center_ignores_extraction_downsampling_only` to cover the extraction-downsampling case.

### Testing
- Ran `pytest localrec/tests/test_protocol_localized_extraction_scaling.py` and the revised scaling tests passed.
- Existing tests asserting crop-center behavior remained and passed after the change.
- New and updated tests include `test_display_center_uses_source_micrograph_grid` and `test_display_center_ignores_extraction_downsampling_only`, both succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27d11d98408326bc410a21fc554627)